### PR TITLE
--npm flag for npm owner add

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
   "author": "max ogden",
   "license": "BSD",
   "dependencies": {
-    "ghauth": "0.0.2",
-    "request": "^2.34.0"
+    "find-npm-by-github": "^1.0.0",
+    "ghauth": "^0.3.1",
+    "minimist": "^1.1.0",
+    "request": "^2.49.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,14 @@ collaborator
 collaborator maxogden
 ```
 
+You can also specify the `--npm` flag to automatically add them as an owner
+on npm. Be aware that it uses the module [find-npm-by-github](https://www.npmjs.org/package/find-npm-by-github)
+to guess the npm name of the github user.
+
+So you should check the message `Added <npmuser> to module <yourmodule>`  on
+stderr in case the npm user name was wrongly determined.
+
+
 ## example
 
 ```


### PR DESCRIPTION
I added a `--npm` flag for adding the user as an npm owner as suggested in #1 . It will use [this module](https://github.com/finnp/find-npm-by-github) to determine to npm user name. This is not bullet proof but should work most of the time.
